### PR TITLE
Fix for editable state not being observed on touchesMoved

### DIFF
--- a/EDStarRating/EDStarRating.m
+++ b/EDStarRating/EDStarRating.m
@@ -306,8 +306,11 @@
     [self setNeedsDisplay];
 }
 #else
--(void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {
-   
+-(void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
+{
+    if( !editable )
+        return;
+    
     UITouch *touch = [touches anyObject];
     CGPoint touchLocation = [touch locationInView:self];
     self.rating =[self starsForPoint:touchLocation]; 


### PR DESCRIPTION
The editable flag was not being checked in touchesMoved, making the star rating editable when it was set to not be.
