### PR TITLE
Fixed problem when touch is cancelled by a multitouch gesture.

### DIFF
--- a/EDStarRating/EDStarRating.m
+++ b/EDStarRating/EDStarRating.m
@@ -356,6 +356,19 @@
     
 }
 
+#if EDSTAR_IOS
+- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
+    if( !editable )
+        return;
+    
+    if( self.delegate && [self.delegate respondsToSelector:@selector(starsSelectionChanged:rating:)] )
+        [self.delegate starsSelectionChanged:self rating:self.rating];
+    
+    if( self.returnBlock)
+        self.returnBlock(self.rating);
+}
+#endif
+
 
 #pragma mark - Tint color Support
 -(void)setStarImage:(EDImage *)image


### PR DESCRIPTION
Situation:
- I limited user to edit rating from 1 up to 5, 0 is not an option;
- To limit it, I've implemented `starsSelectionChanged:rating:`protocol;
- When user drag to 0, it change to 1 again, but user can drag to 0 and without touch up, tap in another button so the rating will be 0.

This commit fix it.
