### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A configurable star rating control for OSX and iOS, similar to those found in iT
 [![Badge w/ Version](https://cocoapod-badges.herokuapp.com/v/EDStarRating/badge.png)](https://cocoadocs.org/docsets/EDStarRating)
 [![Badge w/ Platform](https://cocoapod-badges.herokuapp.com/p/EDStarRating/badge.svg)](https://cocoadocs.org/docsets/EDStarRating)
 
-###Installation
+### Installation
 
 The easiest way to install EDStarRating is via [CocoaPods](http://cocoapods.org). Add this line to your Podfile:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
